### PR TITLE
Add Jest tests for mostrarSoluciones with jsdom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+coverage/

--- a/JS/__mocks__/firebase-app.js
+++ b/JS/__mocks__/firebase-app.js
@@ -1,0 +1,1 @@
+export const initializeApp = () => ({});

--- a/JS/__mocks__/firebase-auth.js
+++ b/JS/__mocks__/firebase-auth.js
@@ -1,0 +1,3 @@
+export const getAuth = () => ({});
+export const signOut = () => Promise.resolve();
+export const onAuthStateChanged = () => {};

--- a/JS/__mocks__/firebase-database.js
+++ b/JS/__mocks__/firebase-database.js
@@ -1,0 +1,3 @@
+export const getDatabase = () => ({});
+export const ref = () => ({});
+export const get = () => Promise.resolve({});

--- a/JS/__tests__/app_buscador.test.js
+++ b/JS/__tests__/app_buscador.test.js
@@ -1,0 +1,46 @@
+import { mostrarSoluciones } from '../app_buscador';
+
+describe('mostrarSoluciones', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <ul id="solutionList"></ul>
+      <div id="imageModal" style="display:none">
+        <span class="close">x</span>
+        <img id="imgModal" />
+        <div id="caption"></div>
+      </div>
+    `;
+  });
+
+  test('agrega pasos e imágenes', () => {
+    const errorData = {
+      Solucion: ['Paso 1', 'Paso 2'],
+      Imagenes: [
+        { Posicion: 1, URL: 'http://example.com/img1.jpg' },
+        { Posicion: 2, URL: 'http://example.com/img2.jpg' }
+      ]
+    };
+
+    mostrarSoluciones(errorData);
+
+    const items = document.querySelectorAll('#solutionList li');
+    expect(items.length).toBe(4);
+    expect(items[0].textContent).toBe('Paso 1');
+    expect(items[1].querySelector('img').src).toBe('http://example.com/img1.jpg');
+    expect(items[2].textContent).toBe('Paso 2');
+    expect(items[3].querySelector('img').src).toBe('http://example.com/img2.jpg');
+  });
+
+  test('cerrar modal oculta el contenedor', () => {
+    const errorData = { Solucion: ['Paso único'], Imagenes: [] };
+    mostrarSoluciones(errorData);
+
+    const modal = document.getElementById('imageModal');
+    const closeBtn = document.querySelector('.close');
+
+    modal.style.display = 'block';
+    closeBtn.click();
+
+    expect(modal.style.display).toBe('none');
+  });
+});

--- a/JS/app_buscador.js
+++ b/JS/app_buscador.js
@@ -50,7 +50,7 @@ function limpiarDetallesError() {
     document.getElementById("solutionList").innerHTML = "";
 }
 
-function mostrarSoluciones(errorData) {
+export function mostrarSoluciones(errorData) {
     const solutionList = document.getElementById("solutionList");
     solutionList.innerHTML = "";
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  presets: [
+    ["@babel/preset-env", { targets: { node: "current" } }]
+  ]
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^https://www\\.gstatic\\.com/firebasejs/9.15.0/(.*)$': '<rootDir>/JS/__mocks__/$1'
+  },
+  transform: {
+    '^.+\\.js$': 'babel-jest'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "st",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@babel/core": "^7.23.0",
+    "@babel/preset-env": "^7.23.0",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0"
+  }
+}


### PR DESCRIPTION
## Summary
- configure Jest with jsdom and Babel
- mock Firebase imports for testing
- add unit tests for `mostrarSoluciones`

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a74e8ab4883269cce90ba58e77dcf